### PR TITLE
Don't hardcode pkg-config fullpath

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ build_flags =
 	-D SHOW_TIMING=0
 	-D DATE_TIME_RTC=1
 	-I lib/externals
-	!/usr/bin/pkg-config --cflags --libs lib_freetype/lib/pkgconfig/freetype2.pc
+	!pkg-config --cflags --libs lib_freetype/lib/pkgconfig/freetype2.pc
 build_unflags = 
 	${common.build_unflags}
 lib_extra_dirs = 
@@ -60,8 +60,8 @@ build_flags =
 	-D EPUB_LINUX_BUILD=1
 	-D EPUB_INKPLATE_BUILD=0
 	-I lib/externals
-	!/usr/bin/pkg-config --cflags --libs gtk+-3.0
-	!/usr/bin/pkg-config --cflags --libs freetype2
+	!pkg-config --cflags --libs gtk+-3.0
+	!pkg-config --cflags --libs freetype2
 build_unflags = 
 	${common.build_unflags}
 lib_extra_dirs = 


### PR DESCRIPTION
My `pkg-config` on macOS is at `/opt/homebrew/bin/pkg-config`. This change removes hardcoding the full path to `/usr/bin/pkg-config` so that PlatformIO will just use the `pkg-config` picked up from `PATH`.

Any reason not to do this?